### PR TITLE
fix: add missing optional peer dependency `js-git`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,13 @@
   "bugs": {
     "url": "https://github.com/creationix/git-node-fs/issues"
   },
-  "homepage": "https://github.com/creationix/git-node-fs"
+  "homepage": "https://github.com/creationix/git-node-fs",
+  "peerDependencies": {
+    "js-git": "^0.7.8"
+  },
+  "peerDependenciesMeta": {
+    "js-git": {
+      "optional": true
+    }
+  }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `fs-db` mixing tries to require `js-git` without declaring it as a dependency
https://github.com/creationix/git-node-fs/blob/4be44a27815181b0e3c340779bf691ab7e3da94f/mixins/fs-db.js#L1

**How did you fix it?**

Added `js-git` as an optional peer dependency